### PR TITLE
Check there are queued messages before trying removing last

### DIFF
--- a/MTStatusBarOverlay.m
+++ b/MTStatusBarOverlay.m
@@ -627,6 +627,7 @@ kDetailViewWidth, kHistoryTableRowHeight*kMaxHistoryTableRowCount + kStatusBarHe
 	if (!self.reallyHidden && [self.visibleStatusLabel.text isEqualToString:message]) {
 		// remove unneccesary message
 		@synchronized(self.messageQueue) {
+          if (self.messageQueue.count)
 			[self.messageQueue removeLastObject];
 		}
         
@@ -700,6 +701,7 @@ kDetailViewWidth, kHistoryTableRowHeight*kMaxHistoryTableRowCount + kStatusBarHe
                              
                              // remove the message from the queue
                              @synchronized(self.messageQueue) {
+                               if (self.messageQueue.count)
                                  [self.messageQueue removeLastObject];
                              }
                              
@@ -722,6 +724,7 @@ kDetailViewWidth, kHistoryTableRowHeight*kMaxHistoryTableRowCount + kStatusBarHe
         
         // remove the message from the queue
         @synchronized(self.messageQueue) {
+          if (self.messageQueue.count)
             [self.messageQueue removeLastObject];
         }
         


### PR DESCRIPTION
I noticed some exceptions raised because of this.
These checks doesn't change MTStatusBarOverlay behavior at all, but makes code more robust and prevents unecessary exceptions.

Side note: having a `~/.gdbinit` with `future-break objc_exception_throw` helps detecting these. ;)
