### PR TITLE
Dark Theme : Small fix, remove Labels shadows

### DIFF
--- a/MTStatusBarOverlay.m
+++ b/MTStatusBarOverlay.m
@@ -1175,6 +1175,9 @@ kDetailViewWidth, kHistoryTableRowHeight*kMaxHistoryTableRowCount + kStatusBarHe
                 self.finishedLabel.textColor = kDarkThemeTextColor;
                 break;
         }
+        self.statusLabel1.shadowColor = nil;
+        self.statusLabel2.shadowColor = nil;
+        self.finishedLabel.shadowColor = nil;
 
 		self.activityIndicator.activityIndicatorViewStyle = kDarkThemeActivityIndicatorViewStyle;
 		self.detailView.backgroundColor = kDarkThemeDetailViewBackgroundColor;


### PR DESCRIPTION
Noticed that when switching styles from dark to light themes, the shadow was really ugly on dark one, so just removed it.
