### PR TITLE
Fix rootViewController by using appDelegate.window instead of keyWindow.

### DIFF
--- a/MTStatusBarOverlay.m
+++ b/MTStatusBarOverlay.m
@@ -480,7 +480,7 @@ kDetailViewWidth, kHistoryTableRowHeight*kMaxHistoryTableRowCount + kStatusBarHe
 ////////////////////////////////////////////////////////////////////////
 
 - (UIViewController *)rootViewController {
-    return [[UIApplication sharedApplication] keyWindow].rootViewController;
+    return [UIApplication sharedApplication].delegate.window.rootViewController;
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#78 seems to cause many crashes when app uses other UIWindows

e.g. SVProgressHUD, custom-UIAlertView, etc,
since `keyWindow` does not have to be app's main window.

I fixed it by using appDelegate.window instead.
