### PR TITLE
Prevented delegate call when hide animation was canceled

### DIFF
--- a/MTStatusBarOverlay.m
+++ b/MTStatusBarOverlay.m
@@ -811,10 +811,12 @@ kDetailViewWidth, kHistoryTableRowHeight*kMaxHistoryTableRowCount + kStatusBarHe
                      animations:^{
 		[self setHidden:YES useAlpha:YES];
 	} completion:^(BOOL finished) {
-		// call delegate
-		if ([self.delegate respondsToSelector:@selector(statusBarOverlayDidHide)]) {
-			[self.delegate statusBarOverlayDidHide];
-		}
+        if(finished) {
+            // call delegate
+            if ([self.delegate respondsToSelector:@selector(statusBarOverlayDidHide)]) {
+                [self.delegate statusBarOverlayDidHide];
+            }
+        }
 	}];
 }
 


### PR DESCRIPTION
If a new message is posted after the hide animation is started but before it is finished, the animation is cancelled. I've added a check for the "finished" flag to prevent calling the delegate's statusBarOverlayDidHide in such cases.
