### PR TITLE
Adding compatibility with the UIStatusBarStyleLightContent style.

### DIFF
--- a/MTStatusBarOverlay.m
+++ b/MTStatusBarOverlay.m
@@ -1188,7 +1188,7 @@ kDetailViewWidth, kHistoryTableRowHeight*kMaxHistoryTableRowCount + kStatusBarHe
 - (void)setStatusBarBackgroundForStyle:(UIStatusBarStyle)style {
 	// gray status bar?
 	// on iPad the Default Status Bar Style is black too
-	if (style == UIStatusBarStyleDefault && !IsIPad && !IsIPhoneEmulationMode) {
+	if ((style == UIStatusBarStyleDefault || style == UIStatusBarStyleLightContent) && !IsIPad && !IsIPhoneEmulationMode) {
 		// choose image depending on size
 		if (self.shrinked) {
 			self.statusBarBackgroundImageView.image = [self.defaultStatusBarImageShrinked stretchableImageWithLeftCapWidth:2.0f topCapHeight:0.0f];


### PR DESCRIPTION
I made this change just to maintain compatibility with the UIStatusBarStyleLightContent style. Otherwise, defaultBackgroundColor is overridden by blackColor.
