### PR TITLE
Fixed bug with black screen on iOS 9

### DIFF
--- a/MTStatusBarOverlay.m
+++ b/MTStatusBarOverlay.m
@@ -279,8 +279,8 @@ kDetailViewWidth, kHistoryTableRowHeight*kMaxHistoryTableRowCount + kStatusBarHe
 #pragma mark Lifecycle
 ////////////////////////////////////////////////////////////////////////
 
-- (id)initWithFrame:(CGRect)frame {
-    if ((self = [super initWithFrame:frame])) {
+- (id)init {
+    if ((self = [super init])) {
         CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
         
 		// only use height of 20px even is status bar is doubled
@@ -295,7 +295,7 @@ kDetailViewWidth, kHistoryTableRowHeight*kMaxHistoryTableRowCount + kStatusBarHe
         self.frame = statusBarFrame;
 		self.alpha = 0.f;
 		self.hidden = NO;
-        
+        self.backgroundColor = [UIColor clearColor];
 		// Default Small size: just show Activity Indicator
 		smallFrame_ = CGRectMake(statusBarFrame.size.width - kWidthSmall, 0.f, kWidthSmall, statusBarFrame.size.height);
         


### PR DESCRIPTION
Changed initWithFrame to init because in init method super calls _resizeWindowToFullScreenIfNessesary and it sets frame as full screen.
Added setting clear background color to self because after tap and view shrink there are black background of self.
